### PR TITLE
fix raw_cfg_pins and raw_set_pins calls

### DIFF
--- a/pyBusPirate/BinaryMode/BitBang.py
+++ b/pyBusPirate/BinaryMode/BitBang.py
@@ -107,11 +107,11 @@ class BBIO:
 		return 1
 
 	def raw_cfg_pins(self, config):
-		self.port.write(0x40 | config)
+		self.port.write(chr(0x40 | config))
 		self.timeout(0.1)
 
 	def raw_set_pins(self, config):
-		self.port.write(0x80 | config)
+		self.port.write(chr(0x80 | config))
 		self.timeout(0.1)
 
 	def timeout(self, timeout=0.1):


### PR DESCRIPTION
Hi, 

small fix

parameter of port.write() mus by a string not a int.
