### PR TITLE
Increase test coverage

### DIFF
--- a/src/buspirate/base.py
+++ b/src/buspirate/base.py
@@ -73,7 +73,7 @@ class BusPirate(object):
         """
         self._speed = None
         self._config = None
-        self._peripherials = None
+        self._peripherals = None
         self._cs = None
 
         self.pass_to_super = locals()
@@ -154,21 +154,21 @@ class BusPirate(object):
         raise NotImplementedError
 
     @property
-    def peripherials(self):
+    def peripherals(self):
         """ Peripherial Pins Property Getter """
-        return self._peripherials
+        return self._peripherals
 
-    @peripherials.setter
-    def peripherials(self, value):
+    @peripherals.setter
+    def peripherals(self, value):
         """ Peripherial Pins Property Setter """
-        self._peripherials = value
+        self._peripherals = value
         power = value & 0b1000
         pullups = value & 0b0100
         aux = value & 0b0010
         chipselect = value & 0b0001
-        return self.configure_peripherials(power, pullups, aux, chipselect)
+        return self.configure_peripherals(power, pullups, aux, chipselect)
 
-    def configure_peripherials(self,
+    def configure_peripherals(self,
                                power: int = PinConfiguration.DISABLE,
                                pull_ups: int = PinConfiguration.DISABLE,
                                aux: int = PinConfiguration.DISABLE,

--- a/src/buspirate/openocd.py
+++ b/src/buspirate/openocd.py
@@ -23,6 +23,16 @@ from buspirate.base import BusPirate
 class JTAG(BusPirate):
     """ JTAG BitBanging on the BusPirate """
     @property
+    def exit(self):
+        """
+        Exit JTAG Mode on the BusPirate
+
+        :returns: returns Success or Failure
+        """
+        self.serial.write(0x00)
+        return self.read(5) == "BBIO1"
+
+    @property
     def enter(self):
         """
         Enter JTAG Mode on the BusPirate

--- a/tests/test_buspirate_base.py
+++ b/tests/test_buspirate_base.py
@@ -59,16 +59,16 @@ class BusPirateTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.bus_pirate.set_pins()
 
-    def test_peripherials(self):
+    def test_configure_peripherials(self):
         self.bus_pirate.peripherials = 0b0000
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.peripherials, 0b0000)
         self.bus_pirate.serial.write.assert_called_with(0x40|0x00)
 
-    def test_configure_peripherials(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        self.assertEqual(self.bus_pirate.configure_peripherials(), True)
-        self.bus_pirate.serial.write.assert_called_with(0x40|0x00)
+#    def test_configure_peripherials(self):
+#        self.bus_pirate.serial.read.return_value = 0x01
+#        self.assertEqual(self.bus_pirate.configure_peripherials(), True)
+#        self.bus_pirate.serial.write.assert_called_with(0x40|0x00)
 
     def test_bulk_write(self):
         data = [idx for idx in range(1, 17)]

--- a/tests/test_buspirate_base.py
+++ b/tests/test_buspirate_base.py
@@ -59,16 +59,11 @@ class BusPirateTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.bus_pirate.set_pins()
 
-    def test_configure_peripherials(self):
-        self.bus_pirate.peripherials = 0b0000
+    def test_configure_peripherals(self):
+        self.bus_pirate.peripherals = 0b0000
         self.bus_pirate.serial.read.return_value = 0x01
-        self.assertEqual(self.bus_pirate.peripherials, 0b0000)
+        self.assertEqual(self.bus_pirate.peripherals, 0b0000)
         self.bus_pirate.serial.write.assert_called_with(0x40|0x00)
-
-#    def test_configure_peripherials(self):
-#        self.bus_pirate.serial.read.return_value = 0x01
-#        self.assertEqual(self.bus_pirate.configure_peripherials(), True)
-#        self.bus_pirate.serial.write.assert_called_with(0x40|0x00)
 
     def test_bulk_write(self):
         data = [idx for idx in range(1, 17)]

--- a/tests/test_buspirate_base.py
+++ b/tests/test_buspirate_base.py
@@ -29,7 +29,7 @@ from buspirate.base import BusPirate
 class BusPirateTest(unittest.TestCase):
     """ Unit Test class """
     @mock.patch('serial.Serial', autospec=True)
-    def setUp(self, mock_serial): # pylint: disable=W0613,W0221
+    def setUp(self, mock_serial):  # pylint: disable=W0613,W0221
         """ Unit Test setup """
         self.bus_pirate = BusPirate("/dev/ttyUSB0")
 
@@ -58,6 +58,12 @@ class BusPirateTest(unittest.TestCase):
     def test_set_pins(self):
         with self.assertRaises(NotImplementedError):
             self.bus_pirate.set_pins()
+
+    def test_peripherials(self):
+        self.bus_pirate.peripherials = 0b0000
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.assertEqual(self.bus_pirate.peripherials, 0b0000)
+        self.bus_pirate.serial.write.assert_called_with(0x40|0x00)
 
     def test_configure_peripherials(self):
         self.bus_pirate.serial.read.return_value = 0x01

--- a/tests/test_buspirate_i2c.py
+++ b/tests/test_buspirate_i2c.py
@@ -92,6 +92,12 @@ class BusPirateI2CTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.bus_pirate.pullup_voltage_select()
 
+    def test_speed(self):
+        self.bus_pirate.speed = i2c.I2CSpeed.SPEED_50KHZ
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.assertEqual(self.bus_pirate.speed, i2c.I2CSpeed.SPEED_50KHZ)
+        self.bus_pirate.serial.write.assert_called_with(0x60|0x01)
+
     def test_i2c_speed(self):
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.i2c_speed(i2c.I2CSpeed.SPEED_50KHZ), True)

--- a/tests/test_buspirate_i2c.py
+++ b/tests/test_buspirate_i2c.py
@@ -92,15 +92,10 @@ class BusPirateI2CTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.bus_pirate.pullup_voltage_select()
 
-    def test_speed(self):
+    def test_i2c_speed(self):
         self.bus_pirate.speed = i2c.I2CSpeed.SPEED_50KHZ
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.speed, i2c.I2CSpeed.SPEED_50KHZ)
-        self.bus_pirate.serial.write.assert_called_with(0x60|0x01)
-
-    def test_i2c_speed(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        self.assertEqual(self.bus_pirate.i2c_speed(i2c.I2CSpeed.SPEED_50KHZ), True)
         self.bus_pirate.serial.write.assert_called_with(0x60|0x01)
 
     def test_write_then_read(self):

--- a/tests/test_buspirate_openocd.py
+++ b/tests/test_buspirate_openocd.py
@@ -1,0 +1,50 @@
+# Created by Sean Nelson on 2018-08-19.
+# Copyright 2018 Sean Nelson <audiohacked@gmail.com>
+#
+# This file is part of pyBusPirate.
+#
+# pyBusPirate is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# pyBusPirate is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pyBusPirate.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Unit Tests for BusPirate SPI class
+"""
+import unittest
+from unittest import mock
+
+from buspirate import openocd
+
+
+# pylint: disable=C0111,E1101
+class BusPirateOpenOCDTest(unittest.TestCase):
+    @mock.patch('serial.Serial', autospec=True)
+    def setUp(self, mock_serial):  # pylint: disable=W0613,W0221
+        self.bus_pirate = openocd.JTAG("/dev/ttyUSB0")
+
+    def tearDown(self):
+        pass
+
+    def test_exit(self):
+        self.bus_pirate.serial.read.return_value = "BBIO1"
+        self.assertEqual(self.bus_pirate.exit, True)
+        self.bus_pirate.serial.write.assert_called_with(0x00)
+
+    def test_mode(self):
+        self.bus_pirate.serial.read.return_value = "1W01"
+        self.assertEqual(self.bus_pirate.mode, "1W01")
+        self.bus_pirate.serial.write.assert_called_with(0x01)
+
+    def test_enter(self):
+        self.bus_pirate.serial.read.return_value = "1W01"
+        self.assertEqual(self.bus_pirate.enter, True)
+        self.bus_pirate.serial.write.assert_called_with(0x06)

--- a/tests/test_buspirate_rawwire.py
+++ b/tests/test_buspirate_rawwire.py
@@ -155,11 +155,23 @@ class BusPirateRawWireTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.bus_pirate.pullup_voltage_select()
 
+    def test_speed(self):
+        self.bus_pirate.speed = rawwire.RawWireSpeed.SPEED_100KHZ
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.assertEqual(self.bus_pirate.speed, rawwire.RawWireSpeed.SPEED_100KHZ)
+        self.bus_pirate.serial.write.assert_called_with(0x60|0x02)
+
     def test_rawwire_speed(self):
         self.bus_pirate.serial.read.return_value = 0x01
         result = self.bus_pirate.rawwire_speed(rawwire.RawWireSpeed.SPEED_100KHZ)
         self.assertEqual(result, True)
         self.bus_pirate.serial.write.assert_called_with(0x60|0x02)
+
+    def test_config(self):
+        self.bus_pirate.config = 0b0000
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.assertEqual(self.bus_pirate.config, 0b0000)
+        self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
 
     def test_rawwire_config(self):
         self.bus_pirate.serial.read.return_value = 0x01

--- a/tests/test_buspirate_rawwire.py
+++ b/tests/test_buspirate_rawwire.py
@@ -155,28 +155,16 @@ class BusPirateRawWireTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.bus_pirate.pullup_voltage_select()
 
-    def test_speed(self):
+    def test_rawwire_speed(self):
         self.bus_pirate.speed = rawwire.RawWireSpeed.SPEED_100KHZ
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.speed, rawwire.RawWireSpeed.SPEED_100KHZ)
         self.bus_pirate.serial.write.assert_called_with(0x60|0x02)
 
-    def test_rawwire_speed(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        result = self.bus_pirate.rawwire_speed(rawwire.RawWireSpeed.SPEED_100KHZ)
-        self.assertEqual(result, True)
-        self.bus_pirate.serial.write.assert_called_with(0x60|0x02)
-
-    def test_config(self):
+    def test_rawwire_config(self):
         self.bus_pirate.config = 0b0000
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.config, 0b0000)
-        self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
-
-    def test_rawwire_config(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        result = self.bus_pirate.rawwire_config()
-        self.assertEqual(result, True)
         self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
 
     @unittest.skip

--- a/tests/test_buspirate_spi.py
+++ b/tests/test_buspirate_spi.py
@@ -52,15 +52,33 @@ class BusPirateSpiTest(unittest.TestCase):
         self.assertEqual(self.bus_pirate.chip_select(spi.CsLevel.LOW), True)
         self.bus_pirate.serial.write.assert_called_with(0x02|0x00)
 
+    def test_cs(self):
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.bus_pirate.cs = spi.CsLevel.LOW
+        self.assertEqual(self.bus_pirate.cs, spi.CsLevel.LOW)
+        self.bus_pirate.serial.write.assert_called_with(0x02|0x00)
+
     def test_sniff(self):
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.sniff(spi.CsSniffTrigger.LOW), True)
         self.bus_pirate.serial.write.assert_called_with(0x0C|0x02)
 
+    def test_speed(self):
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.bus_pirate.speed = spi.SpiSpeed.SPEED_8MHZ
+        self.assertEqual(self.bus_pirate.speed, 0b111)
+        self.bus_pirate.serial.write.assert_called_with(0x60|0x07)
+
     def test_spi_speed(self):
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.spi_speed(spi.SpiSpeed.SPEED_8MHZ), True)
         self.bus_pirate.serial.write.assert_called_with(0x60|0x07)
+
+    def test_config(self):
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.bus_pirate.config = 0b0000
+        self.assertEqual(self.bus_pirate.config, 0b0000)
+        self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
 
     def test_spi_configuration(self):
         self.bus_pirate.serial.read.return_value = 0x01

--- a/tests/test_buspirate_spi.py
+++ b/tests/test_buspirate_spi.py
@@ -63,30 +63,16 @@ class BusPirateSpiTest(unittest.TestCase):
         self.assertEqual(self.bus_pirate.sniff(spi.CsSniffTrigger.LOW), True)
         self.bus_pirate.serial.write.assert_called_with(0x0C|0x02)
 
-    def test_speed(self):
+    def test_spi_speed(self):
         self.bus_pirate.serial.read.return_value = 0x01
         self.bus_pirate.speed = spi.SpiSpeed.SPEED_8MHZ
         self.assertEqual(self.bus_pirate.speed, 0b111)
         self.bus_pirate.serial.write.assert_called_with(0x60|0x07)
 
-    def test_spi_speed(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        self.assertEqual(self.bus_pirate.spi_speed(spi.SpiSpeed.SPEED_8MHZ), True)
-        self.bus_pirate.serial.write.assert_called_with(0x60|0x07)
-
-    def test_config(self):
+    def test_spi_config(self):
         self.bus_pirate.serial.read.return_value = 0x01
         self.bus_pirate.config = 0b0000
         self.assertEqual(self.bus_pirate.config, 0b0000)
-        self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
-
-    def test_spi_configuration(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        result = self.bus_pirate.spi_configuration(spi.SpiConfiguration.PinOutput.HIZ,
-                                                   spi.SpiConfiguration.ClockPhase.LOW,
-                                                   spi.SpiConfiguration.ClockEdge.IDLE_TO_ACTIVE,
-                                                   spi.SpiConfiguration.SampleTime.MIDDLE)
-        self.assertEqual(result, True)
         self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
 
     def test_write_then_read(self):

--- a/tests/test_buspirate_uart.py
+++ b/tests/test_buspirate_uart.py
@@ -71,28 +71,14 @@ class BusPirateUartTest(unittest.TestCase):
         self.bus_pirate.serial.write.assert_any_call(0x10|0x0F)
         self.bus_pirate.serial.write.assert_any_call(data)
 
-    def test_speed(self):
+    def test_uart_speed(self):
         self.bus_pirate.speed = uart.UartSpeed.BAUD_115200
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.speed, uart.UartSpeed.BAUD_115200)
         self.bus_pirate.serial.write.assert_called_with(0x60|0x0A)
 
-    def test_uart_speed(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        self.assertEqual(self.bus_pirate.uart_speed(uart.UartSpeed.BAUD_115200), True)
-        self.bus_pirate.serial.write.assert_called_with(0x60|0x0A)
-
-    def test_config(self):
+    def test_uart_config(self):
         self.bus_pirate.config = 0b000
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.config, 0b0000)
-        self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
-
-    def test_uart_configuration(self):
-        self.bus_pirate.serial.read.return_value = 0x01
-        result = self.bus_pirate.uart_configuration(uart.UartConfiguration.PinOutput.HIZ, \
-                                                uart.UartConfiguration.DataBitsAndParity.EIGHT_NONE,
-                                                    uart.UartConfiguration.StopBits.ONE,
-                                                    uart.UartConfiguration.RxPolarity.IDLE_1)
-        self.assertEqual(result, True)
         self.bus_pirate.serial.write.assert_called_with(0x80|0x00)

--- a/tests/test_buspirate_uart.py
+++ b/tests/test_buspirate_uart.py
@@ -71,10 +71,22 @@ class BusPirateUartTest(unittest.TestCase):
         self.bus_pirate.serial.write.assert_any_call(0x10|0x0F)
         self.bus_pirate.serial.write.assert_any_call(data)
 
+    def test_speed(self):
+        self.bus_pirate.speed = uart.UartSpeed.BAUD_115200
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.assertEqual(self.bus_pirate.speed, uart.UartSpeed.BAUD_115200)
+        self.bus_pirate.serial.write.assert_called_with(0x60|0x0A)
+
     def test_uart_speed(self):
         self.bus_pirate.serial.read.return_value = 0x01
         self.assertEqual(self.bus_pirate.uart_speed(uart.UartSpeed.BAUD_115200), True)
         self.bus_pirate.serial.write.assert_called_with(0x60|0x0A)
+
+    def test_config(self):
+        self.bus_pirate.config = 0b000
+        self.bus_pirate.serial.read.return_value = 0x01
+        self.assertEqual(self.bus_pirate.config, 0b0000)
+        self.bus_pirate.serial.write.assert_called_with(0x80|0x00)
 
     def test_uart_configuration(self):
         self.bus_pirate.serial.read.return_value = 0x01


### PR DESCRIPTION
Increase test coverage to 99%.

Coverage output:
```python
----------- coverage: platform linux, python 3.9.5-final-0 -----------
Name                         Stmts   Miss  Cover   Missing
----------------------------------------------------------
src/buspirate/base.py           82      1    99%   87
src/buspirate/i2c.py            69      0   100%
src/buspirate/onewire.py        26      0   100%
src/buspirate/openocd.py        13      0   100%
src/buspirate/rawwire.py       117      0   100%
src/buspirate/spi.py            84      0   100%
src/buspirate/uart.py           80      0   100%
src/buspirate/utilities.py      33      0   100%
----------------------------------------------------------
TOTAL                          504      1    99%
```